### PR TITLE
Improve snapshot freshness for cloud cameras (Ring, Nest, etc.)

### DIFF
--- a/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
+++ b/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
@@ -78,6 +78,17 @@ blueprint:
       selector:
         boolean:
 
+    capture_delay:
+      name: "Capture Delay (seconds)"
+      description: "Wait time before capturing. Increase for cloud cameras (Ring, Nest) that need time to process new video. Default 1s works for local cameras, use 3-5s for cloud cameras."
+      default: 1
+      selector:
+        number:
+          min: 0
+          max: 10
+          step: 1
+          unit_of_measurement: "s"
+
 mode: single
 max_exceeded: silent
 
@@ -89,6 +100,7 @@ variables:
   user_prompt: !input custom_prompt
   time_start: !input notify_start
   time_end: !input notify_end
+  delay_seconds: !input capture_delay
   # Default prompt - factual and deterministic
   default_prompt: "Briefly describe what you see. Only state what is clearly visible. Do not speculate. If a person is visible, describe their appearance and actions. 2-3 sentences max."
   # Build service names from device IDs
@@ -113,9 +125,9 @@ condition:
     before: !input notify_end
 
 action:
-  # Wait for camera to capture
+  # Wait for camera to capture (increase for cloud cameras like Ring/Nest)
   - delay:
-      seconds: 1
+      seconds: "{{ delay_seconds }}"
 
   # Analyze camera with prompt
   - service: ha_video_vision.analyze_camera


### PR DESCRIPTION
- Add retry mechanism with exponential backoff for snapshot capture
- Detect unchanged/stale snapshots and retry automatically
- Add configurable 'Capture Delay' setting in blueprint (0-10 seconds)
- Use more retries (4) and longer delays for cloud cameras without streams
- Add warning log when using snapshot-only mode for cloud cameras
- Improve logging to help debug stale image issues

For Ring and other cloud cameras that don't provide real-time streams, increase the 'Capture Delay' to 3-5 seconds to allow time for the cloud to process new video before capturing.

Fixes #7