### PR TITLE
Add facial recognition integration via ha-addons

### DIFF
--- a/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
+++ b/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
@@ -2,7 +2,9 @@ blueprint:
   name: "HA Video Vision - Camera Alert"
   description: >
     When person is detected, record video, run AI analysis,
-    and send mobile notifications with snapshot. Works with iOS and Android via Nabu Casa.
+    and send mobile notifications with snapshot. Optionally identify known
+    faces using the Facial Recognition add-on (github.com/LosCV29/ha-addons).
+    Works with iOS and Android via Nabu Casa.
   domain: automation
   author: "HA Video Vision Integration"
   source_url: "https://github.com/LosCV29/ha-video-vision/blob/main/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml"
@@ -89,6 +91,32 @@ blueprint:
           step: 1
           unit_of_measurement: "s"
 
+    # Facial Recognition Settings
+    facial_recognition_enabled:
+      name: "Enable Facial Recognition"
+      description: "Identify known faces using the Facial Recognition add-on. Add face photos to /homeassistant/camera_faces/PersonName/"
+      default: false
+      selector:
+        boolean:
+
+    facial_recognition_url:
+      name: "Facial Recognition Server URL"
+      description: "URL of the Facial Recognition add-on (install from github.com/LosCV29/ha-addons)"
+      default: "http://homeassistant.local:8100"
+      selector:
+        text:
+
+    facial_recognition_confidence:
+      name: "Facial Recognition Confidence"
+      description: "Minimum confidence % to report a face match"
+      default: 50
+      selector:
+        number:
+          min: 10
+          max: 100
+          step: 5
+          unit_of_measurement: "%"
+
 mode: single
 max_exceeded: silent
 
@@ -101,6 +129,10 @@ variables:
   time_start: !input notify_start
   time_end: !input notify_end
   delay_seconds: !input capture_delay
+  # Facial recognition settings
+  face_rec_enabled: !input facial_recognition_enabled
+  face_rec_url: !input facial_recognition_url
+  face_rec_confidence: !input facial_recognition_confidence
   # Default prompt - factual and deterministic
   default_prompt: "Briefly describe what you see. Only state what is clearly visible. Do not speculate. If a person is visible, describe their appearance and actions. 2-3 sentences max."
   # Build service names from device IDs
@@ -143,10 +175,39 @@ action:
           - condition: template
             value_template: "{{ result.success == true }}"
         sequence:
+          # Facial recognition (if enabled and snapshot available)
+          - choose:
+              - conditions:
+                  - condition: template
+                    value_template: "{{ face_rec_enabled and result.snapshot_path }}"
+                sequence:
+                  - service: ha_video_vision.identify_faces
+                    data:
+                      image_path: "{{ result.snapshot_path }}"
+                      server_url: "{{ face_rec_url }}"
+                      min_confidence: "{{ face_rec_confidence }}"
+                    response_variable: face_result
+            default:
+              - variables:
+                  face_result:
+                    success: false
+                    summary: ""
+
           - variables:
               tag: "ha_video_vision_{{ camera_input }}"
               notification_title: "{{ result.friendly_name }}"
-              notification_message: "{{ result.description if result.description else 'Motion detected on camera' }}"
+              # Include facial recognition results in message if available
+              face_info: >
+                {% if face_rec_enabled and face_result.success and face_result.summary and face_result.summary != 'No known faces' %}
+                  Identified: {{ face_result.summary }}
+                {% endif %}
+              notification_message: >
+                {% set desc = result.description if result.description else 'Motion detected on camera' %}
+                {% if face_rec_enabled and face_result.success and face_result.summary and face_result.summary != 'No known faces' %}
+                  {{ face_result.summary }} - {{ desc }}
+                {% else %}
+                  {{ desc }}
+                {% endif %}
 
           # Send to all devices
           - repeat:

--- a/custom_components/ha_video_vision/const.py
+++ b/custom_components/ha_video_vision/const.py
@@ -108,6 +108,7 @@ DEFAULT_SNAPSHOT_QUALITY: Final = 85  # JPEG quality 1-100
 # =============================================================================
 SERVICE_ANALYZE_CAMERA: Final = "analyze_camera"
 SERVICE_RECORD_CLIP: Final = "record_clip"
+SERVICE_IDENTIFY_FACES: Final = "identify_faces"
 
 # =============================================================================
 # ATTRIBUTES

--- a/custom_components/ha_video_vision/services.yaml
+++ b/custom_components/ha_video_vision/services.yaml
@@ -52,3 +52,34 @@ record_clip:
           step: 1
           unit_of_measurement: seconds
 
+identify_faces:
+  name: Identify Faces
+  description: Identify faces in an image using the Facial Recognition add-on (github.com/LosCV29/ha-addons).
+  fields:
+    image_path:
+      name: Image Path
+      description: Path to the image file (e.g., from analyze_camera snapshot_path)
+      required: true
+      example: "/media/ha_video_vision/driveway_latest.jpg"
+      selector:
+        text:
+    server_url:
+      name: Server URL
+      description: URL of the facial recognition add-on server
+      required: true
+      default: "http://homeassistant.local:8100"
+      example: "http://homeassistant.local:8100"
+      selector:
+        text:
+    min_confidence:
+      name: Minimum Confidence
+      description: Minimum confidence percentage to include in results
+      required: false
+      default: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 5
+          unit_of_measurement: "%"
+


### PR DESCRIPTION
- Add identify_faces service to call Facial Recognition add-on
- Update blueprint with facial recognition inputs (enable, URL, confidence)
- Blueprint automatically identifies faces and includes names in notifications
- Face photos stored in /homeassistant/camera_faces/PersonName/
- Works with github.com/LosCV29/ha-addons facial-recognition add-on