### PR TITLE
Fix null pointer dereference in record_clip service

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -587,7 +587,8 @@ class VideoAnalyzer:
         os.makedirs(self.snapshot_dir, exist_ok=True)
         video_path = None
         
-        friendly_name = self.hass.states.get(entity_id).attributes.get("friendly_name", entity_id)
+        state = self.hass.states.get(entity_id)
+        friendly_name = state.attributes.get("friendly_name", entity_id) if state else entity_id
         safe_name = entity_id.replace("camera.", "").replace(".", "_")
         
         try:


### PR DESCRIPTION
The code was calling .attributes.get() on the result of hass.states.get(entity_id) without checking if it returned None. This would cause an AttributeError crash if the entity was deleted or unavailable. Applied the same safe pattern used elsewhere in the codebase (line 730).