### PR TITLE
Add facial recognition URL configuration to options flow

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -61,6 +61,12 @@ from .const import (
     SERVICE_ANALYZE_CAMERA,
     SERVICE_RECORD_CLIP,
     SERVICE_IDENTIFY_FACES,
+    # Facial Recognition
+    CONF_FACIAL_RECOGNITION_URL,
+    CONF_FACIAL_RECOGNITION_ENABLED,
+    CONF_FACIAL_RECOGNITION_CONFIDENCE,
+    DEFAULT_FACIAL_RECOGNITION_URL,
+    DEFAULT_FACIAL_RECOGNITION_CONFIDENCE,
     # Attributes
     ATTR_CAMERA,
     ATTR_DURATION,
@@ -148,8 +154,8 @@ SERVICE_RECORD_SCHEMA = vol.Schema(
 SERVICE_IDENTIFY_FACES_SCHEMA = vol.Schema(
     {
         vol.Required("image_path"): cv.string,
-        vol.Required("server_url"): cv.string,
-        vol.Optional("min_confidence", default=50): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
+        vol.Optional("server_url"): cv.string,
+        vol.Optional("min_confidence"): vol.All(vol.Coerce(int), vol.Range(min=0, max=100)),
     }
 )
 
@@ -219,8 +225,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     async def handle_identify_faces(call: ServiceCall) -> dict[str, Any]:
         """Handle identify_faces service call for facial recognition add-on."""
         image_path = call.data["image_path"]
-        server_url = call.data["server_url"]
-        min_confidence = call.data.get("min_confidence", 50)
+        # Use configured URL if not provided in service call
+        server_url = call.data.get("server_url") or config.get(
+            CONF_FACIAL_RECOGNITION_URL, DEFAULT_FACIAL_RECOGNITION_URL
+        )
+        min_confidence = call.data.get("min_confidence") or config.get(
+            CONF_FACIAL_RECOGNITION_CONFIDENCE, DEFAULT_FACIAL_RECOGNITION_CONFIDENCE
+        )
 
         return await analyzer.identify_faces(image_path, server_url, min_confidence)
 

--- a/custom_components/ha_video_vision/const.py
+++ b/custom_components/ha_video_vision/const.py
@@ -104,6 +104,17 @@ DEFAULT_SNAPSHOT_DIR: Final = "/media/ha_video_vision"
 DEFAULT_SNAPSHOT_QUALITY: Final = 85  # JPEG quality 1-100
 
 # =============================================================================
+# FACIAL RECOGNITION
+# =============================================================================
+CONF_FACIAL_RECOGNITION_URL: Final = "facial_recognition_url"
+CONF_FACIAL_RECOGNITION_ENABLED: Final = "facial_recognition_enabled"
+CONF_FACIAL_RECOGNITION_CONFIDENCE: Final = "facial_recognition_confidence"
+
+DEFAULT_FACIAL_RECOGNITION_URL: Final = "http://localhost:8100"
+DEFAULT_FACIAL_RECOGNITION_ENABLED: Final = False
+DEFAULT_FACIAL_RECOGNITION_CONFIDENCE: Final = 50
+
+# =============================================================================
 # SERVICE NAMES
 # =============================================================================
 SERVICE_ANALYZE_CAMERA: Final = "analyze_camera"

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "4.5.3"
+  "version": "4.5.4"
 }

--- a/custom_components/ha_video_vision/services.yaml
+++ b/custom_components/ha_video_vision/services.yaml
@@ -65,10 +65,10 @@ identify_faces:
         text:
     server_url:
       name: Server URL
-      description: URL of the facial recognition add-on server
-      required: true
-      default: "http://homeassistant.local:8100"
-      example: "http://homeassistant.local:8100"
+      description: URL of the facial recognition server. Leave empty to use the configured URL from integration settings.
+      required: false
+      default: ""
+      example: "http://localhost:8100"
       selector:
         text:
     min_confidence:

--- a/custom_components/ha_video_vision/strings.json
+++ b/custom_components/ha_video_vision/strings.json
@@ -49,7 +49,8 @@
           "cameras": "Select Cameras",
           "voice_aliases": "Voice Aliases",
           "video_quality": "Video Quality",
-          "ai_settings": "AI Settings"
+          "ai_settings": "AI Settings",
+          "facial_recognition": "Facial Recognition"
         }
       },
       "default_provider": {
@@ -131,6 +132,15 @@
         "data": {
           "vllm_max_tokens": "Max Response Length (tokens)",
           "vllm_temperature": "Temperature (creativity)"
+        }
+      },
+      "facial_recognition": {
+        "title": "Facial Recognition",
+        "description": "Configure the Facial Recognition add-on. {url_hint}",
+        "data": {
+          "facial_recognition_enabled": "Enable Facial Recognition",
+          "facial_recognition_url": "Server URL",
+          "facial_recognition_confidence": "Minimum Confidence"
         }
       }
     },

--- a/custom_components/ha_video_vision/translations/en.json
+++ b/custom_components/ha_video_vision/translations/en.json
@@ -49,7 +49,8 @@
           "cameras": "Select Cameras",
           "voice_aliases": "Voice Aliases",
           "video_quality": "Video Quality",
-          "ai_settings": "AI Settings"
+          "ai_settings": "AI Settings",
+          "facial_recognition": "Facial Recognition"
         }
       },
       "default_provider": {
@@ -131,6 +132,15 @@
         "data": {
           "vllm_max_tokens": "Max Response Length (tokens)",
           "vllm_temperature": "Temperature (creativity)"
+        }
+      },
+      "facial_recognition": {
+        "title": "Facial Recognition",
+        "description": "Configure the Facial Recognition add-on. {url_hint}",
+        "data": {
+          "facial_recognition_enabled": "Enable Facial Recognition",
+          "facial_recognition_url": "Server URL",
+          "facial_recognition_confidence": "Minimum Confidence"
         }
       }
     },


### PR DESCRIPTION
- Add CONF_FACIAL_RECOGNITION_URL, ENABLED, and CONFIDENCE constants
- Add "Facial Recognition" menu option in options flow
- Create async_step_facial_recognition with URL validation
- Update identify_faces service to use configured URL as default
- Make server_url parameter optional in service schema
- Add translation strings for facial recognition config
- Bump version to 4.5.4

The facial recognition URL now defaults to http://localhost:8100 and can be configured in Settings -> Integrations -> HA Video Vision -> Configure -> Facial Recognition