### PR TITLE
fix: Improve cloud camera (Ring/Nest) video and snapshot handling

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.0"
+  "version": "5.0.1"
 }


### PR DESCRIPTION
- Fix staleness detection bug in _get_camera_snapshot: Previously the first snapshot was always returned immediately without checking for freshness. Now properly compares multiple snapshots to detect stale cached images from cloud cameras.

- Enhance _get_stream_url to try multiple methods for cloud cameras:
  1. Standard async_get_stream_source
  2. Check entity attributes for stream_source
  3. Try camera.turn_on to activate idle cameras before retrieval

- Increase retry attempts and delays for cloud camera snapshots (5 retries with 2s initial delay) to give cloud APIs time to provide fresh images.

- Improve error messages for Google Gemini and OpenRouter providers when no video is available, providing clear solutions for users with cloud cameras.

Fixes #32