### PR TITLE
fix: Add content_in_root to hacs.json for proper HACS update detection

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,6 @@
 {
   "name": "HA Video Vision",
+  "content_in_root": false,
   "render_readme": true,
   "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
HACS requires the content_in_root: false directive to properly detect updates when the integration code is in custom_components/ rather than the repository root. This was causing users to have to manually trigger "Update Information" in HACS to see available updates.

Fixes #16