### PR TITLE
fix: Eliminate recording startup delay for faster frame capture

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.9"
+  "version": "5.0.10"
 }


### PR DESCRIPTION
- Skip FPS probing entirely when video_fps_percent is 100% (default) This was adding 1-3 seconds of delay before recording started
- Add low-latency flags to ffprobe and reduce timeout from 10s to 3s
- Recording now starts IMMEDIATELY when person is detected

This should fix the issue where frames show person walking away instead of approaching, because recording was starting too late.