### PR TITLE
fix: Remove aggressive ffmpeg flags that broke video recording

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.10"
+  "version": "5.0.11"
 }


### PR DESCRIPTION
The previous low-latency flags (probesize=32, analyzeduration=0) were too aggressive and caused ffmpeg to fail on many cameras, resulting in timeout after 18 seconds and fallback to snapshot mode.

Changes:
- Remove overly aggressive probesize and analyzeduration flags
- Keep only safe low-latency flags (nobuffer, low_delay) for RTSP
- Add proper error logging to capture ffmpeg stderr when recording fails
- Log the actual ffmpeg command for debugging

This should fix video recording for doorbell cameras and other RTSP streams.