### PR TITLE
fix: Reduce RTSP recording delay with low-latency ffmpeg flags

### DIFF
--- a/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
+++ b/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
@@ -100,8 +100,8 @@ blueprint:
 
     frame_position:
       name: "Notification Frame Position (%)"
-      description: "Which frame from the video to use for the notification image. 0% = first frame (start of video), 50% = middle frame, 100% = last frame (end of video). Adjust based on your camera's behavior - use lower values if subjects leave quickly, higher values if there's camera lag."
-      default: 50
+      description: "Which frame from the video to use for the notification image. 0% = first frame, 50% = middle, 100% = last frame. IMPORTANT: Due to RTSP keyframe delay, recording starts 1-2 seconds after trigger. Use LOW values (0-20%) if people walk away quickly. Use 50% only if people linger at the camera."
+      default: 20
       selector:
         number:
           min: 0
@@ -119,8 +119,8 @@ blueprint:
 
     facial_recognition_frame_position:
       name: "Facial Recognition Frame Position (%)"
-      description: "Which frame to use for facial recognition. This is SEPARATE from the notification image. Use 50% (middle) or higher to capture faces after people have walked closer to the camera. Default 50%."
-      default: 50
+      description: "Which frame to use for facial recognition. SEPARATE from notification image. Use LOW values (10-30%) to capture faces early before people turn away. Higher values only work if people linger facing the camera. Due to keyframe delay, 0% may still be 1-2 seconds after trigger."
+      default: 20
       selector:
         number:
           min: 0

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.11"
+  "version": "5.0.12"
 }

--- a/custom_components/ha_video_vision/services.yaml
+++ b/custom_components/ha_video_vision/services.yaml
@@ -37,7 +37,7 @@ analyze_camera:
         boolean:
     facial_recognition_frame_position:
       name: Facial Recognition Frame Position
-      description: Which frame to use for facial recognition (0-100%). This is SEPARATE from the notification image. Use 50% (middle) or higher to capture faces after people have walked closer to the camera. If not set, uses the same frame as the notification.
+      description: Which frame to use for facial recognition (0-100%). SEPARATE from notification image. Use LOW values (10-30%) to capture faces early before people leave. Due to RTSP keyframe delay, recording starts 1-2 seconds after trigger. If not set, uses the same frame as the notification.
       required: false
       selector:
         number:
@@ -54,7 +54,7 @@ analyze_camera:
         boolean:
     frame_position:
       name: Notification Frame Position
-      description: Which frame from the video to use for the notification image (0-100%). 0% = first frame (start), 50% = middle frame, 100% = last frame (end). Adjust based on camera behavior - lower values if subjects leave quickly, higher values if there's camera lag.
+      description: Which frame from the video to use for the notification image (0-100%). 0% = first frame, 50% = middle, 100% = last. IMPORTANT - Due to RTSP keyframe delay, recording starts 1-2 seconds after trigger. Use LOW values (0-20%) if people walk away quickly. Default 20%.
       required: false
       selector:
         number:


### PR DESCRIPTION
- Add aggressive low-latency ffmpeg options based on Frigate's proven config:
  - use_wallclock_as_timestamps for better timestamp handling
  - analyzeduration=1 (minimal analysis without failing like 0 does)
  - probesize=32000 (32KB - much smaller than default 5MB)
  - nobuffer+genpts+discardcorrupt flags
  - avoid_negative_ts for clean timestamps

- Speed up frame extraction with explicit mjpeg format

- Add timing logs to track recording delays for debugging

- Update default frame positions from 50% to 20%:
  - RTSP keyframe (GOP) delay means recording starts 1-2s after trigger
  - Lower frame positions capture action earlier
  - Updated blueprint and services.yaml with clear explanations

- Bump version to 5.0.12

Note: True zero-delay requires pre-buffering (continuous recording) which would be a major architectural change. These ffmpeg optimizations reduce delay but cannot eliminate the inherent RTSP keyframe wait time.