### PR TITLE
fix: DRASTICALLY simplify code - remove all bloat

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.14"
+  "version": "5.0.15"
 }


### PR DESCRIPTION
REMOVED:
- FPS probing (was adding 2-5 seconds delay)
- Hardware encoder detection (was running ffmpeg tests)
- All timing/debug code
- 100+ lines of unnecessary complexity

SIMPLIFIED:
- ffmpeg command is now 10 lines instead of 50
- Direct libx264 encoding (ultrafast preset)
- No caching overhead
- No extra subprocess calls

This was the working code. Stop over-engineering.

Version 5.0.15