### PR TITLE
fix: Improve AI prompts to detect people at edges of frame

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -1025,10 +1025,10 @@ class VideoAnalyzer:
             prompt = user_query
         else:
             prompt = (
-                "Describe what you see in this camera feed. "
-                "Only mention people if you clearly see them - do not assume or guess. "
-                "Note any activity, vehicles, or notable events. "
-                "Be concise (2-3 sentences). Say 'no activity' if nothing notable is happening."
+                "CAREFULLY scan the ENTIRE frame including all edges, corners, and background areas. "
+                "Report ANY people visible - even if small, distant, partially obscured, or at the edges. "
+                "Also report moving vehicles. For people, describe their location and actions. "
+                "Be concise (2-3 sentences). Say 'no activity' only if absolutely nothing is present."
             )
 
         # OPTIMIZATION: Run AI analysis and snapshot saves in PARALLEL

--- a/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
+++ b/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
@@ -154,7 +154,7 @@ variables:
   face_rec_frame_pos: !input facial_recognition_frame_position
   timeline_enabled: !input save_to_timeline
   # Default prompt - reports ALL people/vehicles whether moving or stationary
-  default_prompt: "Describe any people, vehicles, or notable activity visible. Report ALL people and vehicles, whether moving or stationary. For people, describe their appearance and actions. Ignore static background objects like parked cars and structures. If no people, vehicles, or notable activity are present, respond: 'No activity observed.' 2-3 sentences max."
+  default_prompt: "CAREFULLY scan the ENTIRE frame including all edges, corners, and background areas. Report ANY people visible - even if small, distant, partially obscured, or at the edges of frame. Also report moving vehicles. For people, describe their location in frame and what they're doing. Ignore parked cars and static structures. If absolutely no people or moving vehicles are present after thorough inspection, respond: 'No activity observed.' 2-3 sentences max."
   # Build service names from device IDs
   device_services: >
     {% set ns = namespace(services=[]) %}


### PR DESCRIPTION
The AI was missing people who appeared small or at the edges of the camera frame. Updated prompts to explicitly instruct the AI to:
- Scan the ENTIRE frame including edges, corners, and background
- Report people even if small, distant, or partially obscured
- Only say "no activity" after thorough inspection