### PR TITLE
fix: Respect blueprint prompts, only use verbose mode for voice checks

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.17"
+  "version": "5.0.18"
 }


### PR DESCRIPTION
Voice check detection now distinguishes between:
- Voice checks: short commands like "check the back yard" (< 100 chars with check/show/look keywords)
- Blueprint prompts: detailed instructions that should be used as-is

Blueprint prompts are detected by:
- Length > 150 chars, OR
- Contains "sentences" or "report all"

This ensures automation prompts like "Describe any people... 2-3 sentences max" are used exactly as configured, while voice checks get the rich descriptive response.