### PR TITLE
perf: Add low-latency FFmpeg flags for faster recording start

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -745,8 +745,17 @@ class VideoAnalyzer:
         return None
 
     async def _build_ffmpeg_cmd(self, stream_url: str, duration: int, output_path: str) -> list[str]:
-        """Build simple ffmpeg command."""
+        """Build ffmpeg command with low-latency optimizations for instant recording."""
         cmd = ["ffmpeg", "-y"]
+
+        # LOW LATENCY FLAGS - minimize time before recording starts
+        # These reduce the ~1-2 second delay FFmpeg normally takes to probe the stream
+        cmd.extend([
+            "-fflags", "nobuffer",          # Don't buffer input - start immediately
+            "-flags", "low_delay",          # Low latency decoding mode
+            "-probesize", "32",             # Minimal probe size (bytes) - faster stream detection
+            "-analyzeduration", "0",        # Skip duration analysis - start recording NOW
+        ])
 
         if stream_url.startswith("rtsp://"):
             cmd.extend(["-rtsp_transport", "tcp"])

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.21"
+  "version": "5.0.22"
 }


### PR DESCRIPTION
Added FFmpeg optimizations to minimize the delay before recording starts:
- nobuffer: Don't buffer input stream
- low_delay: Low latency decoding mode
- probesize 32: Minimal probe size for faster stream detection
- analyzeduration 0: Skip duration analysis, start recording immediately

These flags reduce the typical 1-2 second FFmpeg probe delay, ensuring the person/activity that triggered motion is captured in the video.