### PR TITLE
perf: Parallel stream URL + snapshot lookup for zero-delay recording

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.22"
+  "version": "5.0.23"
 }


### PR DESCRIPTION
Major optimization to eliminate ALL bottlenecks before FFmpeg starts:

1. Stream URL lookup starts IMMEDIATELY when service is called
2. Snapshot capture starts in PARALLEL (same millisecond)
3. Metadata lookups happen while waiting (non-blocking)
4. The MOMENT stream URL is ready, FFmpeg starts recording

New _record_video_with_url() function takes pre-fetched URL directly, eliminating the duplicate async lookup that was causing delay.

Recording now starts the absolute earliest possible moment.