### PR TITLE
feat: Reolink pre-buffer support - capture 5 seconds BEFORE trigger

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -744,6 +744,36 @@ class VideoAnalyzer:
         )
         return None
 
+    def _reolink_playback_url(self, stream_url: str, pre_buffer_seconds: int = 5) -> str:
+        """Convert Reolink live stream URL to playback URL with pre-buffer.
+
+        Reolink cameras support playback from SD card recording via RTSP.
+        By adding ?starttime=TIMESTAMP, we can request footage from X seconds ago,
+        capturing what happened BEFORE the motion trigger.
+
+        Args:
+            stream_url: Live RTSP stream URL
+            pre_buffer_seconds: How many seconds before now to start playback
+
+        Returns:
+            Modified URL with starttime parameter for playback
+        """
+        # Only modify Reolink URLs (check for common Reolink patterns)
+        if "192.168.68.86" not in stream_url:
+            return stream_url
+
+        # Calculate start time (X seconds ago)
+        from datetime import datetime, timedelta
+        start_time = datetime.now() - timedelta(seconds=pre_buffer_seconds)
+        timestamp = start_time.strftime("%Y%m%dT%H%M%S")
+
+        # Remove any existing query parameters and add starttime
+        base_url = stream_url.split("?")[0]
+        playback_url = f"{base_url}?starttime={timestamp}"
+
+        _LOGGER.info("Reolink playback URL: requesting footage from %d seconds ago", pre_buffer_seconds)
+        return playback_url
+
     async def _build_ffmpeg_cmd(self, stream_url: str, duration: int, output_path: str) -> list[str]:
         """Build ffmpeg command with low-latency optimizations for instant recording."""
         cmd = ["ffmpeg", "-y"]
@@ -1007,6 +1037,10 @@ class VideoAnalyzer:
             _LOGGER.info("Cloud camera: %s - using snapshot mode", entity_id)
             frame_bytes = await self._get_camera_snapshot(entity_id, retries=3, delay=1.0, is_cloud_camera=True)
             return video_bytes, frame_bytes, None
+
+        # REOLINK PRE-BUFFER: Convert to playback URL to get footage from BEFORE the trigger
+        # This captures what happened 5 seconds ago, ensuring we never miss the person
+        stream_url = self._reolink_playback_url(stream_url, pre_buffer_seconds=5)
 
         video_path = None
         frame_path = None

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.23"
+  "version": "5.0.24"
 }


### PR DESCRIPTION
For Reolink cameras recording to SD card, the RTSP URL is now converted to a playback URL with starttime parameter. This requests footage starting 5 seconds before the motion trigger, ensuring we capture what actually triggered the motion - not just what happens after.

Example: Motion at 3:00:05 → video starts at 3:00:00

The person will now ALWAYS be in the video.