### PR TITLE
fix: Remove 'no activity' instruction from LLM prompts

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -1171,9 +1171,9 @@ class VideoAnalyzer:
             prompt = (
                 "CAREFULLY scan the ENTIRE frame including all edges, corners, and background areas. "
                 "Report ANY people, animals, or pets visible - even if small, distant, partially obscured, or at the edges. "
-                "Also report moving vehicles. For people, describe their location and actions. "
+                "Also report moving vehicles. For people, always describe their appearance, location, and what they are doing. "
                 "For animals, identify the type (dog, cat, etc.) and what they are doing. "
-                "Be concise (2-3 sentences). Say 'no activity' only if absolutely nothing is present."
+                "Be concise (2-3 sentences)."
             )
 
         # Save facial recognition frame separately if it exists and differs from notification frame

--- a/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
+++ b/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
@@ -154,7 +154,7 @@ variables:
   face_rec_frame_pos: !input facial_recognition_frame_position
   timeline_enabled: !input save_to_timeline
   # Default prompt - reports ALL people/vehicles whether moving or stationary
-  default_prompt: "CAREFULLY scan the ENTIRE frame including all edges, corners, and background areas. Report ANY people visible - even if small, distant, partially obscured, or at the edges of frame. Also report moving vehicles. For people, describe their location in frame and what they're doing. Ignore parked cars and static structures. If absolutely no people or moving vehicles are present after thorough inspection, respond: 'No activity observed.' 2-3 sentences max."
+  default_prompt: "CAREFULLY scan the ENTIRE frame including all edges, corners, and background areas. Report ANY people visible - even if small, distant, partially obscured, or at the edges of frame. Also report moving vehicles. For people, always describe their appearance, location, and what they are doing. Ignore parked cars and static structures. Be concise (2-3 sentences)."
   # Build service names from device IDs
   device_services: >
     {% set ns = namespace(services=[]) %}

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.30"
+  "version": "5.0.31"
 }


### PR DESCRIPTION
The AI was interpreting people standing still as "not notable" and responding with "no activity" instead of describing them. Changed prompts to always describe visible people's appearance, location, and actions.

- __init__.py: Remove 'no activity' fallback from default prompt
- camera_alert.yaml: Remove 'No activity observed' instruction
- Bump version to 5.0.31