### PR TITLE
fix: Facial recognition not showing in notifications

### DIFF
--- a/blueprints/automation/camera_alert.yaml
+++ b/blueprints/automation/camera_alert.yaml
@@ -183,10 +183,11 @@ action:
               notification_title: "{{ custom_title if custom_title else result.friendly_name }}"
               # Include facial recognition results in message if available
               notification_message: >
-                {% set desc = result.description if result.description else 'Motion detected on camera' %}
-                {% set face_rec = result.get('face_recognition', {}) %}
-                {% if face_rec.get('success') and face_rec.get('summary') and face_rec.get('summary') != 'No known faces' %}
-                  {{ face_rec.summary }} - {{ desc }}
+                {% set desc = result.description | default('Motion detected on camera') %}
+                {% set face_rec = result.face_recognition | default({}) %}
+                {% set face_summary = face_rec.summary | default('') %}
+                {% if face_rec.success | default(false) and face_summary and face_summary != 'No known faces' %}
+                  {{ face_summary }} - {{ desc }}
                 {% else %}
                   {{ desc }}
                 {% endif %}

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.31"
+  "version": "5.0.32"
 }


### PR DESCRIPTION
- Fixed Jinja2 template using .get() which doesn't work in HA templates
- Changed to use | default() filter instead for proper template rendering
- Face was being detected correctly but results weren't appearing in notification

Version: 5.0.32