### PR TITLE
fix: Facial recognition confidence threshold too strict for ensemble …

### DIFF
--- a/custom_components/ha_video_vision/const.py
+++ b/custom_components/ha_video_vision/const.py
@@ -107,7 +107,7 @@ CONF_FACIAL_RECOGNITION_CONFIDENCE: Final = "facial_recognition_confidence"
 
 DEFAULT_FACIAL_RECOGNITION_URL: Final = "http://localhost:8100"
 DEFAULT_FACIAL_RECOGNITION_ENABLED: Final = False
-DEFAULT_FACIAL_RECOGNITION_CONFIDENCE: Final = 50
+DEFAULT_FACIAL_RECOGNITION_CONFIDENCE: Final = 35  # Lowered for ensemble mode (1/3 votes often ~40-50%)
 
 # =============================================================================
 # TIMELINE (Calendar-based event history)

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.38"
+  "version": "5.0.39"
 }


### PR DESCRIPTION
…mode

- Lowered default confidence threshold from 50% to 35% to accommodate ensemble mode where 1/3 votes often results in 40-50% confidence
- Use server's summary directly when it contains identified faces, trusting the server's thresholding logic for ensemble mode
- This fixes faces being filtered out even when the server identified them

Version: 5.0.39