### PR TITLE
fix: Empty string bug causing server summary to never be used

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.40"
+  "version": "5.0.41"
 }


### PR DESCRIPTION
- Removed empty string from no_faces_phrases check (empty string matches everything in Python)
- Simplified logic for determining when to use server vs client summary
- This ensures server's summary (like "carlos (3/3 votes, 41.4%)") is passed through

Version: 5.0.41