### PR TITLE
feat: Replace server-based facial recognition with LLM-based approach

### DIFF
--- a/blueprints/automation/camera_alert.yaml
+++ b/blueprints/automation/camera_alert.yaml
@@ -3,7 +3,7 @@ blueprint:
   description: >
     When person is detected, record video, run AI analysis,
     and send mobile notifications with snapshot. Optionally identify
-    known faces using the Facial Recognition add-on.
+    known faces using LLM-based facial recognition (compares against reference photos).
     Works with iOS and Android via Nabu Casa.
   domain: automation
   author: "HA Video Vision Integration"
@@ -98,13 +98,35 @@ blueprint:
           step: 1
           unit_of_measurement: "s"
 
-    # Facial Recognition
+    frame_position:
+      name: "Notification Frame Position (%)"
+      description: "Which frame from the video to use for the notification image. 0% = first frame, 50% = middle, 100% = last frame."
+      default: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 10
+          unit_of_measurement: "%"
+
+    # Facial Recognition (LLM-based)
     facial_recognition_enabled:
       name: "Enable Facial Recognition"
-      description: "Identify known faces using the Facial Recognition add-on. Configure the server URL in the integration settings."
+      description: "Identify known faces using LLM-based recognition. Store reference photos in the directory configured in integration settings (e.g., /config/camera_faces/PersonName/)."
       default: false
       selector:
         boolean:
+
+    facial_recognition_frame_position:
+      name: "Facial Recognition Frame Position (%)"
+      description: "Which frame to use for facial recognition. SEPARATE from notification image. Use 50% (middle) or higher to capture faces after people have walked closer to the camera."
+      default: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 10
+          unit_of_measurement: "%"
 
     # Timeline
     save_to_timeline:
@@ -127,10 +149,12 @@ variables:
   time_start: !input notify_start
   time_end: !input notify_end
   delay_seconds: !input capture_delay
+  frame_pos: !input frame_position
   face_rec_enabled: !input facial_recognition_enabled
+  face_rec_frame_pos: !input facial_recognition_frame_position
   timeline_enabled: !input save_to_timeline
-  # Default prompt - reports ALL people/vehicles/animals whether moving or stationary
-  default_prompt: "IMPORTANT: Scan the ENTIRE frame carefully, including background, edges, and shadows. Report ANY people visible, no matter how small or distant. Report ALL vehicles present. For people, describe their location, appearance and actions. For animals, identify the type and behavior. For vehicles, note type, color, and position. Only say 'No activity observed' if the frame is completely empty of people, animals, and vehicles. 2-3 sentences max."
+  # Default prompt - reports ALL people/vehicles whether moving or stationary
+  default_prompt: "CAREFULLY scan the ENTIRE frame including all edges, corners, and background areas. Report ANY people visible - even if small, distant, partially obscured, or at the edges of frame. Also report moving vehicles. For people, always describe their appearance, location, and what they are doing. Ignore parked cars and static structures. Be concise (2-3 sentences)."
   # Build service names from device IDs
   device_services: >
     {% set ns = namespace(services=[]) %}
@@ -161,15 +185,18 @@ action:
       - delay:
           seconds: "{{ delay_seconds }}"
 
-  # Analyze camera with prompt - uses integration's video_duration setting
-  # Recording starts INSTANTLY when delay is 0
+  # Analyze camera with prompt - VIDEO ONLY analysis
+  # Frame position determines which video frame is used for notification image
+  # Facial recognition uses a separate frame position for better face capture
   - service: ha_video_vision.analyze_camera
     data:
       camera: !input camera_name
       # Duration omitted - uses integration's configured video_duration for consistent recording length
       user_query: "{{ user_prompt if user_prompt else default_prompt }}"
       facial_recognition: "{{ face_rec_enabled }}"
+      facial_recognition_frame_position: "{{ face_rec_frame_pos }}"
       remember: "{{ timeline_enabled }}"
+      frame_position: "{{ frame_pos }}"
     response_variable: result
 
   # Send notifications if successful
@@ -183,11 +210,10 @@ action:
               notification_title: "{{ custom_title if custom_title else result.friendly_name }}"
               # Include facial recognition results in message if available
               notification_message: >
-                {% set desc = result.description | default('Motion detected on camera') %}
-                {% set face_rec = result.face_recognition | default({}) %}
-                {% set face_summary = face_rec.summary | default('') %}
-                {% if face_rec.success | default(false) and face_summary and face_summary != 'No known faces' %}
-                  {{ face_summary }} - {{ desc }}
+                {% set desc = result.description if result.description else 'Motion detected on camera' %}
+                {% set face_rec = result.get('face_recognition', {}) %}
+                {% if face_rec.get('success') and face_rec.get('summary') and face_rec.get('summary') != 'No known faces' %}
+                  {{ face_rec.summary }} - {{ desc }}
                 {% else %}
                   {{ desc }}
                 {% endif %}
@@ -211,9 +237,10 @@ action:
                       # Priority
                       ttl: 0
                       priority: high
-                      # Android
+                      # Android - bigText style prevents text cutoff
                       channel: "ha_video_vision"
                       sticky: true
+                      style: big_text
                       # iOS
                       attachment:
                         url: "{{ result.snapshot_url }}"

--- a/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
+++ b/custom_components/ha_video_vision/blueprints/automation/camera_alert.yaml
@@ -3,7 +3,7 @@ blueprint:
   description: >
     When person is detected, record video, run AI analysis,
     and send mobile notifications with snapshot. Optionally identify
-    known faces using the Facial Recognition add-on.
+    known faces using LLM-based facial recognition (compares against reference photos).
     Works with iOS and Android via Nabu Casa.
   domain: automation
   author: "HA Video Vision Integration"
@@ -109,10 +109,10 @@ blueprint:
           step: 10
           unit_of_measurement: "%"
 
-    # Facial Recognition
+    # Facial Recognition (LLM-based)
     facial_recognition_enabled:
       name: "Enable Facial Recognition"
-      description: "Identify known faces using the Facial Recognition add-on. Configure the server URL in the integration settings."
+      description: "Identify known faces using LLM-based recognition. Store reference photos in the directory configured in integration settings (e.g., /config/camera_faces/PersonName/)."
       default: false
       selector:
         boolean:

--- a/custom_components/ha_video_vision/const.py
+++ b/custom_components/ha_video_vision/const.py
@@ -99,15 +99,13 @@ DEFAULT_SNAPSHOT_DIR: Final = "/media/ha_video_vision"
 DEFAULT_SNAPSHOT_QUALITY: Final = 85  # JPEG quality 1-100
 
 # =============================================================================
-# FACIAL RECOGNITION
+# FACIAL RECOGNITION (LLM-based with reference photos)
 # =============================================================================
-CONF_FACIAL_RECOGNITION_URL: Final = "facial_recognition_url"
 CONF_FACIAL_RECOGNITION_ENABLED: Final = "facial_recognition_enabled"
-CONF_FACIAL_RECOGNITION_CONFIDENCE: Final = "facial_recognition_confidence"
+CONF_FACIAL_RECOGNITION_DIRECTORY: Final = "facial_recognition_directory"
 
-DEFAULT_FACIAL_RECOGNITION_URL: Final = "http://localhost:8100"
 DEFAULT_FACIAL_RECOGNITION_ENABLED: Final = False
-DEFAULT_FACIAL_RECOGNITION_CONFIDENCE: Final = 35  # Lowered for ensemble mode (1/3 votes often ~40-50%)
+DEFAULT_FACIAL_RECOGNITION_DIRECTORY: Final = "/config/camera_faces"  # Directory with subfolders per person
 
 # =============================================================================
 # TIMELINE (Calendar-based event history)

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.0.42"
+  "version": "5.1.0"
 }

--- a/custom_components/ha_video_vision/strings.json
+++ b/custom_components/ha_video_vision/strings.json
@@ -155,11 +155,10 @@
       },
       "facial_recognition": {
         "title": "Facial Recognition",
-        "description": "Configure the Facial Recognition add-on. {url_hint}",
+        "description": "LLM-based facial recognition using reference photos. {directory_hint}",
         "data": {
           "facial_recognition_enabled": "Enable Facial Recognition",
-          "facial_recognition_url": "Server URL",
-          "facial_recognition_confidence": "Minimum Confidence"
+          "facial_recognition_directory": "Reference Photos Directory"
         }
       },
       "timeline": {


### PR DESCRIPTION
Completely replaces the DeepFace server-based facial recognition with an LLM-based approach that uses reference photos:

- Remove CONF_FACIAL_RECOGNITION_URL and CONF_FACIAL_RECOGNITION_CONFIDENCE
- Add CONF_FACIAL_RECOGNITION_DIRECTORY for storing reference photos
- Implement _load_reference_photos() to read photos from person subfolders
- Implement _identify_faces_with_llm() using Google, OpenRouter, or local LLM
- Support for Google Gemini, OpenRouter, and local vLLM providers
- Parse LLM response to extract "Name XX%" format

Reference photos are stored in subdirectories named after each person:
  /config/camera_faces/Carlos/*.jpg
  /config/camera_faces/Elise/*.jpg

The LLM compares the camera frame against up to 3 reference photos per person and returns identification with confidence percentage.

Version bump to 5.1.0 (major feature change)