### PR TITLE
fix: Remove translation placeholder to fix cache issue

### DIFF
--- a/custom_components/ha_video_vision/config_flow.py
+++ b/custom_components/ha_video_vision/config_flow.py
@@ -896,9 +896,7 @@ class VideoVisionOptionsFlow(config_entries.OptionsFlow):
                     selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
                 ),
             }),
-            description_placeholders={
-                "directory_hint": "Directory containing subfolders per person (e.g., /config/camera_faces/Carlos/)",
-            },
+            description_placeholders={},
         )
 
     async def async_step_timeline(

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.1.2"
+  "version": "5.1.3"
 }

--- a/custom_components/ha_video_vision/strings.json
+++ b/custom_components/ha_video_vision/strings.json
@@ -155,7 +155,7 @@
       },
       "facial_recognition": {
         "title": "Facial Recognition",
-        "description": "LLM-based facial recognition using reference photos. {directory_hint}",
+        "description": "LLM-based facial recognition. Store reference photos in subfolders per person (e.g., /config/camera_faces/Carlos/).",
         "data": {
           "facial_recognition_enabled": "Enable Facial Recognition",
           "facial_recognition_directory": "Reference Photos Directory"

--- a/custom_components/ha_video_vision/translations/en.json
+++ b/custom_components/ha_video_vision/translations/en.json
@@ -140,7 +140,7 @@
       },
       "facial_recognition": {
         "title": "Facial Recognition",
-        "description": "LLM-based facial recognition using reference photos. {directory_hint}",
+        "description": "LLM-based facial recognition. Store reference photos in subfolders per person (e.g., /config/camera_faces/Carlos/).",
         "data": {
           "facial_recognition_enabled": "Enable Facial Recognition",
           "facial_recognition_directory": "Reference Photos Directory"


### PR DESCRIPTION
Embed the full description text directly instead of using a placeholder. This works around Home Assistant's aggressive translation caching.