### PR TITLE
fix: Resolve blocking scandir and local vLLM token overflow in facial…

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.1.3"
+  "version": "5.1.4"
 }


### PR DESCRIPTION
… recognition

- Wrap directory scanning in asyncio.to_thread() to avoid blocking event loop
- Limit local vLLM to 1 photo per person (vs 3 for cloud providers)
- Add image resizing (512x512) for local vLLM to reduce token usage
- Limit local vLLM to max 4 people to prevent token overflow
- Bump version to 5.1.4