### PR TITLE
feat: Extract AI snapshot from video for synchronized detection

### DIFF
--- a/custom_components/ha_video_vision/config_flow.py
+++ b/custom_components/ha_video_vision/config_flow.py
@@ -48,10 +48,12 @@ from .const import (
     CONF_VIDEO_WIDTH,
     CONF_VIDEO_FPS_PERCENT,
     CONF_NOTIFICATION_FRAME_POSITION,
+    CONF_AI_SNAPSHOT_POSITION,
     DEFAULT_VIDEO_DURATION,
     DEFAULT_VIDEO_WIDTH,
     DEFAULT_VIDEO_FPS_PERCENT,
     DEFAULT_NOTIFICATION_FRAME_POSITION,
+    DEFAULT_AI_SNAPSHOT_POSITION,
     # Snapshot
     CONF_SNAPSHOT_DIR,
     CONF_SNAPSHOT_QUALITY,
@@ -843,6 +845,9 @@ class VideoVisionOptionsFlow(config_entries.OptionsFlow):
                     selector.NumberSelectorConfig(min=50, max=100, step=5, unit_of_measurement="%", mode=selector.NumberSelectorMode.SLIDER)
                 ),
                 vol.Required(CONF_NOTIFICATION_FRAME_POSITION, default=current.get(CONF_NOTIFICATION_FRAME_POSITION, DEFAULT_NOTIFICATION_FRAME_POSITION)): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=0, max=100, step=10, unit_of_measurement="%", mode=selector.NumberSelectorMode.SLIDER)
+                ),
+                vol.Required(CONF_AI_SNAPSHOT_POSITION, default=current.get(CONF_AI_SNAPSHOT_POSITION, DEFAULT_AI_SNAPSHOT_POSITION)): selector.NumberSelector(
                     selector.NumberSelectorConfig(min=0, max=100, step=10, unit_of_measurement="%", mode=selector.NumberSelectorMode.SLIDER)
                 ),
                 vol.Optional(CONF_SNAPSHOT_DIR, default=current.get(CONF_SNAPSHOT_DIR, DEFAULT_SNAPSHOT_DIR)): str,

--- a/custom_components/ha_video_vision/const.py
+++ b/custom_components/ha_video_vision/const.py
@@ -81,6 +81,7 @@ CONF_VIDEO_DURATION: Final = "video_duration"
 CONF_VIDEO_WIDTH: Final = "video_width"
 CONF_VIDEO_FPS_PERCENT: Final = "video_fps_percent"
 CONF_NOTIFICATION_FRAME_POSITION: Final = "notification_frame_position"
+CONF_AI_SNAPSHOT_POSITION: Final = "ai_snapshot_position"
 
 DEFAULT_VIDEO_DURATION: Final = 3
 DEFAULT_VIDEO_WIDTH: Final = 1280  # Match LLM Vision default for better detection
@@ -88,6 +89,10 @@ DEFAULT_VIDEO_FPS_PERCENT: Final = 100  # 100% of camera's native FPS
 # Frame position for notification image (percentage of video duration)
 # 0 = first frame, 50 = middle, 100 = last frame
 DEFAULT_NOTIFICATION_FRAME_POSITION: Final = 50
+# Frame position for AI analysis snapshot (percentage of video duration)
+# 0 = first frame (captures motion trigger moment), 50 = middle, 100 = last frame
+# This snapshot is sent to AI alongside the video for improved detection
+DEFAULT_AI_SNAPSHOT_POSITION: Final = 0
 
 # =============================================================================
 # SNAPSHOT SETTINGS

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.1.7"
+  "version": "5.1.9"
 }

--- a/custom_components/ha_video_vision/strings.json
+++ b/custom_components/ha_video_vision/strings.json
@@ -142,6 +142,7 @@
           "video_fps_percent": "Frame Rate",
           "snapshot_quality": "Snapshot Quality",
           "notification_frame_position": "Notification Frame Position (0%=start, 50%=middle, 100%=end)",
+          "ai_snapshot_position": "AI Snapshot Position (0%=start captures trigger moment)",
           "snapshot_dir": "Snapshot Directory"
         }
       },

--- a/custom_components/ha_video_vision/translations/en.json
+++ b/custom_components/ha_video_vision/translations/en.json
@@ -127,6 +127,7 @@
           "video_fps_percent": "Frame Rate",
           "snapshot_quality": "Snapshot Quality",
           "notification_frame_position": "Notification Frame Position (0%=start, 50%=middle, 100%=end)",
+          "ai_snapshot_position": "AI Snapshot Position (0%=start captures trigger moment)",
           "snapshot_dir": "Snapshot Directory"
         }
       },


### PR DESCRIPTION
Replace separate HTTP snapshot capture with video-synchronized snapshot:
- Extract AI snapshot from video at configurable position (default 0% = first frame)
- Send video + AI snapshot together to AI providers for better detection
- Single source of truth - snapshot synchronized with video content
- New ai_snapshot_position config option (0-100%)
- Updated all AI providers (Gemini, OpenRouter, Local vLLM)

This ensures the AI sees exactly what's in the video, eliminating race conditions between separate capture processes.

Version: 5.1.9