### PR TITLE
fix: Improve FFmpeg error logging for stream debugging

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.1"
+  "version": "5.2.2"
 }


### PR DESCRIPTION
- Add debug log showing actual stream URL (with masked credentials)
- Add debug log of full FFmpeg command before execution
- Change stderr logging to capture LAST 2000 chars instead of first 500 (FFmpeg banner often fills first 500 chars, hiding actual error)
- Bump version to 5.2.2