### PR TITLE
fix: Increase FFmpeg probesize and analyzeduration for reliable recor…

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -773,12 +773,12 @@ class VideoAnalyzer:
         cmd = ["ffmpeg", "-y"]
 
         # LOW LATENCY FLAGS - minimize time before recording starts
-        # These reduce the ~1-2 second delay FFmpeg normally takes to probe the stream
+        # Balance between fast startup and reliable stream detection
         cmd.extend([
             "-fflags", "nobuffer",          # Don't buffer input - start immediately
             "-flags", "low_delay",          # Low latency decoding mode
-            "-probesize", "32",             # Minimal probe size (bytes) - faster stream detection
-            "-analyzeduration", "0",        # Skip duration analysis - start recording NOW
+            "-probesize", "32768",          # 32KB probe size - enough to detect stream format
+            "-analyzeduration", "1000000",  # 1 second analysis - allows codec detection
         ])
 
         if stream_url.startswith("rtsp://"):

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.2"
+  "version": "5.2.3"
 }


### PR DESCRIPTION
…ding

The previous ultra-aggressive values (-probesize 32, -analyzeduration 0) caused FFmpeg to fail with "Could not find codec parameters" errors because it couldn't gather enough data to detect the stream format.

New values:
- probesize: 32KB (was 32 bytes) - enough to detect H.264 stream
- analyzeduration: 1 second (was 0) - allows codec parameter detection

This adds a small startup delay but ensures reliable video recording.