### PR TITLE
fix: Remove image fallback - video only for analysis

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.3"
+  "version": "5.2.4"
 }


### PR DESCRIPTION
Images don't provide enough context and cause LLM hallucinations. Now fails cleanly if video recording fails instead of falling back to a single snapshot image.