### PR TITLE
fix: Sync facial recognition with video frames - no snapshot fallback

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.4"
+  "version": "5.2.5"
 }


### PR DESCRIPTION
Previously, facial recognition could use an immediate snapshot taken at trigger time while the AI analyzed a video recorded moments later. This caused mismatches where facial rec identified someone (e.g., "Carlos 85%") but the AI said "No activity observed" because the video captured a different moment.

Changes:
- Always extract facial recognition frame from video (not instant snapshot)
- Use video frame for notification image (ensures sync with AI analysis)
- Remove snapshot fallback for cloud cameras without RTSP (fail cleanly)
- All frames now come from the same video recording

This ensures facial recognition, notification image, and AI analysis all see the exact same content, eliminating timing mismatches on doorbells.

https://claude.ai/code/session_01LnZhoLP2nwxFaSCJQWcySg