### PR TITLE
fix: Optimize FFmpeg for faster RTSP startup on doorbell cameras

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.5"
+  "version": "5.2.6"
 }


### PR DESCRIPTION
Recording was starting 2-3 seconds late, missing the initial detection. FFmpeg was also timing out on unstable Reolink streams.

Changes:
- Reduced probesize from 32KB to 8KB for faster stream detection
- Reduced analyzeduration from 1s to 0.5s
- Added -max_delay 0 to eliminate packet buffering
- Added -avioflags direct for direct I/O
- Added -fflags +discardcorrupt to allow starting mid-stream
- Added -stimeout 5s connection timeout for RTSP
- Increased recording timeout from duration+10 to duration+20 for unstable streams

https://claude.ai/code/session_01LnZhoLP2nwxFaSCJQWcySg