### PR TITLE
fix: Use TCP + ultrafast encoding for reliable recording

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.11"
+  "version": "5.2.12"
 }


### PR DESCRIPTION
UDP with stream copy was producing empty videos (packet loss + keyframe issues).

Changes:
- Back to TCP (reliable, no packet loss)
- Always use ultrafast encoding (reliable output, nearly as fast as copy)
- Added error for empty video files (fail fast with clear message)

https://claude.ai/code/session_01LnZhoLP2nwxFaSCJQWcySg