### PR TITLE
fix: Explicitly map video stream for cameras with undetected pixel fo…

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -806,6 +806,12 @@ class VideoAnalyzer:
 
         cmd.extend(["-i", stream_url, "-t", str(duration)])
 
+        # Explicitly map video stream (fixes Reolink cameras that don't report pixel format)
+        cmd.extend(["-map", "0:v:0"])
+
+        # Force pixel format for streams that don't report it properly
+        cmd.extend(["-pix_fmt", "yuv420p"])
+
         # Always re-encode for reliability (stream copy can fail on keyframe issues)
         # ultrafast + zerolatency is nearly as fast as copy but more reliable
         if self.video_fps_percent < 100:

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.14"
+  "version": "5.2.15"
 }


### PR DESCRIPTION
…rmat

- Add -map 0:v:0 to explicitly select video stream
- Add -pix_fmt yuv420p to force pixel format
- Fixes Reolink cameras that report "h264, none" stream format

https://claude.ai/code/session_01LnZhoLP2nwxFaSCJQWcySg