### PR TITLE
fix: Add retry logic for cameras waking from standby

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.15"
+  "version": "5.2.16"
 }


### PR DESCRIPTION
- Up to 2 retries with 1 second delay between attempts
- Logs warning on retry attempts to help debug
- Still uses VIDEO analysis after successful retry
- Cameras like Reolink often need a "wake up" call first

https://claude.ai/code/session_01LnZhoLP2nwxFaSCJQWcySg