### PR TITLE
fix: Respect configured video duration and quality settings

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.17"
+  "version": "5.2.18"
 }


### PR DESCRIPTION
- Service handlers now use configured video_duration instead of hardcoded 3 seconds
- Video CRF now respects snapshot_quality setting (50%=CRF28, 100%=CRF18)
- Added info logging to confirm settings are applied during recording

https://claude.ai/code/session_01PBiyTEcBgsG1NHpgWJh4db