### PR TITLE
fix: Respect configured video duration and quality settings

### DIFF
--- a/custom_components/ha_video_vision/config_flow.py
+++ b/custom_components/ha_video_vision/config_flow.py
@@ -817,6 +817,7 @@ class VideoVisionOptionsFlow(config_entries.OptionsFlow):
                 vol.Required(CONF_VIDEO_WIDTH, default=str(current.get(CONF_VIDEO_WIDTH) or DEFAULT_VIDEO_WIDTH)): selector.SelectSelector(
                     selector.SelectSelectorConfig(
                         options=[
+                            {"label": "Native (no scaling - sharpest)", "value": "0"},
                             {"label": "480 (fast, low detail)", "value": "480"},
                             {"label": "640 (SD)", "value": "640"},
                             {"label": "720 (HD)", "value": "720"},

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.2.18"
+  "version": "5.2.19"
 }


### PR DESCRIPTION
- Service schema bug: Removed default=3 that was overriding configured video_duration. Now properly uses your slider setting.
- Added native resolution option (no scaling) for maximum sharpness
- FFmpeg now skips scale filter when resolution set to "Native"
- Added camera selection logging to debug wrong camera issues
- Updated log messages to show "native" when using full resolution

Version: 5.2.19

https://claude.ai/code/session_01PBiyTEcBgsG1NHpgWJh4db