### PR TITLE
fix: Add keyframe sync to FFmpeg to prevent grey video frames at start

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.3.9"
+  "version": "5.3.10"
 }


### PR DESCRIPTION
The +nobuffer flag was causing FFmpeg to start capturing mid-stream before receiving a keyframe, resulting in grey/corrupted frames until enough P-frames accumulated to build the image.

Changes:
- Remove +nobuffer flag and increase probesize from 4KB to 32KB
- Set analyzeduration to 1 second to allow keyframe detection
- Apply same keyframe sync flags to frame extraction command
- Bump version to 5.3.10

This fixes the issue where videos would start grey and gradually become visible as P-frames accumulated without a proper reference frame.

https://claude.ai/code/session_01Wt9Fmi8hYyhAkjeg32cAdm