### PR TITLE
fix: Add logging to diagnose missing user recognition

### DIFF
--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.5.4"
+  "version": "5.5.5"
 }


### PR DESCRIPTION
Improved logging to help diagnose why some users (like Elise) aren't being recognized while others (like Carlos) are:

- Log at INFO level when photos are successfully loaded for each person
- Log WARNING when a person's directory exists but has no valid images
- Log WARNING when photos fail to load (was DEBUG)
- Add summary log showing all configured people at startup
- Add explicit f.is_file() check to filter out subdirectories

Check Home Assistant logs for "Facial recognition:" messages to see if Elise's photos are being loaded correctly.

https://claude.ai/code/session_015bzBHyEkKDL3VqAp6YcqDA