### PR TITLE
Fix FPS limiting on RTSP streams with unreliable timestamps

### DIFF
--- a/custom_components/ha_video_vision/__init__.py
+++ b/custom_components/ha_video_vision/__init__.py
@@ -845,6 +845,7 @@ class VideoAnalyzer:
         # ultrafast + zerolatency is nearly as fast as copy but more reliable
         # video_width=0 means native resolution (no scaling)
         vf_filters = []
+        target_fps = None
         if self.video_fps_percent < 100:
             target_fps = max(8, int(30 * self.video_fps_percent / 100))
             vf_filters.append(f"fps={target_fps}")
@@ -860,6 +861,12 @@ class VideoAnalyzer:
             "-tune", "zerolatency",
             "-crf", self._get_video_crf(),  # Use quality setting instead of hardcoded 28
         ])
+
+        # FPS limiting: the fps video filter alone can fail on RTSP/live streams with
+        # unreliable timestamps. The -r output option enforces framerate at the muxer
+        # level based on frame count, which works regardless of input timestamp quality.
+        if target_fps is not None:
+            cmd.extend(["-r", str(target_fps)])
 
         cmd.extend(["-an", output_path])
 
@@ -924,9 +931,10 @@ class VideoAnalyzer:
 
             # Log settings being applied
             res_str = "native" if self.video_width == 0 else str(self.video_width)
+            fps_str = f"{max(8, int(30 * self.video_fps_percent / 100))}fps" if self.video_fps_percent < 100 else "native"
             _LOGGER.info(
-                "Recording clip %s: duration=%ds, resolution=%s, quality=CRF%s",
-                entity_id, duration, res_str, self._get_video_crf()
+                "Recording clip %s: duration=%ds, resolution=%s, quality=CRF%s, fps=%s (%d%%)",
+                entity_id, duration, res_str, self._get_video_crf(), fps_str, self.video_fps_percent
             )
 
             proc = await asyncio.create_subprocess_exec(
@@ -1015,9 +1023,10 @@ class VideoAnalyzer:
 
             # Log settings being applied (helps verify config is respected)
             res_str = "native" if self.video_width == 0 else str(self.video_width)
+            fps_str = f"{max(8, int(30 * self.video_fps_percent / 100))}fps" if self.video_fps_percent < 100 else "native"
             _LOGGER.info(
-                "Recording %s: duration=%ds, resolution=%s, quality=CRF%s, fps=%d%%",
-                entity_id, duration, res_str, self._get_video_crf(), self.video_fps_percent
+                "Recording %s: duration=%ds, resolution=%s, quality=CRF%s, fps=%s (%d%%)",
+                entity_id, duration, res_str, self._get_video_crf(), fps_str, self.video_fps_percent
             )
 
             # Log the FFmpeg command (mask credentials in URL)

--- a/custom_components/ha_video_vision/manifest.json
+++ b/custom_components/ha_video_vision/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/LosCV29/ha-video-vision/issues",
   "iot_class": "local_polling",
   "requirements": ["aiohttp>=3.8.0", "aiofiles>=23.0.0"],
-  "version": "5.6.2"
+  "version": "5.6.3"
 }


### PR DESCRIPTION
## Summary
This PR improves FPS limiting reliability for RTSP and live streams by adding an output-level framerate enforcement option to FFmpeg, complementing the existing video filter approach.

## Key Changes
- **FPS enforcement at muxer level**: Added `-r` output option to FFmpeg command when FPS limiting is enabled. This enforces framerate based on frame count rather than relying solely on input timestamps, which can be unreliable for RTSP/live streams.
- **Improved logging**: Enhanced log messages in `record_clip()` and `_record_video_and_extract_frames()` to display the actual target FPS value (e.g., "24fps") alongside the percentage, making it easier to verify configuration is being applied correctly.
- **Version bump**: Updated to v5.6.3

## Implementation Details
- The `target_fps` variable is now initialized to `None` at the start of `_build_ffmpeg_cmd()` and only set when FPS reduction is needed (`video_fps_percent < 100`)
- The `-r` option is only added to the command when `target_fps` is not `None`, ensuring it doesn't interfere with native framerate recording
- Log messages now calculate and display the actual FPS value (minimum 8fps, maximum 30fps) for better clarity

https://claude.ai/code/session_01UfUVCM53NyKeSu5JfUGrer